### PR TITLE
Query db with cookie info to get users own memories back

### DIFF
--- a/src/database/db_get.js
+++ b/src/database/db_get.js
@@ -1,17 +1,21 @@
 const connect = require('./db_connect');
 
-const getMemories = (userId, callback) => {
-  connect.query(
-    `SELECT memories.id, memories.heading, memories.likes, memories.visits, memories.tag, memories.memory_asset_url, memories.memory_text, memories.media_type
-    FROM memories
-    INNER JOIN users
-    ON users.id = memories.user_id
-    WHERE users.id = $1;`, [userId], (err, res) => {
-      if (err) {
-        return callback(err);
-      }
-      return callback(null, res); // will be refactored
-    });
+const getMemories = (userLogin, callback) => {
+  const userSQLMemories =
+  `SELECT memories.id, memories.heading, memories.likes, memories.visits,
+  memories.tag, memories.memory_asset_url, memories.memory_text,
+  memories.media_type
+  FROM memories
+  INNER JOIN users
+  ON users.id = memories.user_id
+  WHERE users.id = (SELECT users.id FROM users WHERE username = $1 OR email = $1)`;
+
+  connect.query(userSQLMemories, [userLogin], (err, res) => {
+    if (err) {
+      return callback(err);
+    }
+    return callback(null, res);
+  });
 };
 
 const userSQL = 'SELECT * FROM users WHERE username = $1 OR email = $1';

--- a/src/database/db_get.js
+++ b/src/database/db_get.js
@@ -10,12 +10,7 @@ const getMemories = (userLogin, callback) => {
   ON users.id = memories.user_id
   WHERE users.id = (SELECT users.id FROM users WHERE username = $1 OR email = $1)`;
 
-  connect.query(userSQLMemories, [userLogin], (err, res) => {
-    if (err) {
-      return callback(err);
-    }
-    return callback(null, res);
-  });
+  connect.query(userSQLMemories, [userLogin], callback);
 };
 
 const userSQL = 'SELECT * FROM users WHERE username = $1 OR email = $1';

--- a/src/server/controllers/getMemories.js
+++ b/src/server/controllers/getMemories.js
@@ -3,7 +3,7 @@ require('env2')('./config.env');
 const { getMemories } = require('./../../database/db_get');
 
 module.exports = (req, res) => {
-  getMemories(1, (error, memories) => {
+  getMemories(req.cookies.name, (error, memories) => {
     if (error) {
       res.send(error);
       return;


### PR DESCRIPTION
This PR:

Passes cookie info into getMemories so that users own memories are returned
Refactors getMemories so that users.id is returned from the db
Relates #98