### PR TITLE
Liking memories offline

### DIFF
--- a/src/client/d3/d3.js
+++ b/src/client/d3/d3.js
@@ -1,4 +1,4 @@
-const { initTagMenu, showDeleteButton, hoveringOnDelete, hideDeleteButton, initSubmitMemory, tagSorting, constructTagList, showHeading, saveItemsToStorage, removeMemoryFromStoredData, removeMemoriesDeletedOffline, updateOfflineLikes, hoveringOnDeleteSafari, deletePendingMemories } = require('../helpers/helpers.js');
+const { initTagMenu, showDeleteButton, hoveringOnDelete, hideDeleteButton, initSubmitMemory, tagSorting, constructTagList, showHeading, storePendingActions, removeMemoryFromStoredData, removeMemoriesDeletedOffline, updateOfflineLikes, hoveringOnDeleteSafari, deletePendingMemories } = require('../helpers/helpers.js');
 const { animationDuration, width, height, jsonUrl, svg, fdGrp, nodeGrp, linkGrp } = require('./setup.js');
 const { sortWithMax, binByTag, centralMaxNodesByTag, memoryNodesAndLinks } = require('../node_transformations');
 const { appendPopUp, randomPopUp } = require('./modals.js');
@@ -207,7 +207,7 @@ function render(updatedData) {
           success: update,
         });
       } else {
-        saveItemsToStorage('toDelete', { memories: [id] }, id);
+        storePendingActions('toDelete', { memories: [id] }, id);
         const offlineData = removeMemoryFromStoredData(id);
         render(formatData(offlineData));
       }

--- a/src/client/d3/d3.js
+++ b/src/client/d3/d3.js
@@ -1,4 +1,4 @@
-const { initTagMenu, showDeleteButton, hoveringOnDelete, hideDeleteButton, initSubmitMemory, tagSorting, constructTagList, showHeading, saveMemoryIdToStorage, removeMemoryFromStoredData, removeMemoriesDeletedOffline } = require('../helpers/helpers.js');
+const { initTagMenu, showDeleteButton, hoveringOnDelete, hideDeleteButton, initSubmitMemory, tagSorting, constructTagList, showHeading, saveItemsToStorage, removeMemoryFromStoredData, removeMemoriesDeletedOffline, updateOfflineLikes } = require('../helpers/helpers.js');
 const { animationDuration, width, height, jsonUrl, svg, fdGrp, nodeGrp, linkGrp } = require('./setup.js');
 const { sortWithMax, binByTag, centralMaxNodesByTag, memoryNodesAndLinks } = require('../node_transformations');
 const { appendPopUp, randomPopUp } = require('./modals.js');
@@ -243,7 +243,7 @@ function render(updatedData) {
         });
         render(formatData(data));
       } else {
-        saveMemoryIdToStorage(id);
+        saveItemsToStorage('toDelete', { memories: [id] }, id);
         const offlineData = removeMemoryFromStoredData(id);
         render(formatData(offlineData));
       }
@@ -275,6 +275,7 @@ function render(updatedData) {
 if (navigator.onLine) {
   onlineLogic();
   removeMemoriesDeletedOffline(onlineLogic);
+  updateOfflineLikes(onlineLogic);
 } else {
   const offlineData = JSON.parse(localStorage.getItem('data'));
   constructTagList(offlineData);

--- a/src/client/d3/modals.js
+++ b/src/client/d3/modals.js
@@ -1,5 +1,5 @@
 const { svg } = require('./setup');
-const { getRandomInt } = require('./../helpers/helpers');
+const { getRandomInt, saveItemsToStorage } = require('./../helpers/helpers');
 
 const appendPopUp = (data) => {
   const holder = svg
@@ -37,11 +37,15 @@ const appendPopUp = (data) => {
         const newLikeNum = parseInt(d3.select('.likeNumber').text()) + 1;
         const memoryId = data.id;
         d3.select('.likeNumber').text(newLikeNum);
-        $.ajax({
-          type: 'POST',
-          url: '/likes',
-          data: { numLikes: newLikeNum, memoryId },
-        });
+        if (navigator.onLine) {
+          $.ajax({
+            type: 'POST',
+            url: '/likes',
+            data: { numLikes: newLikeNum, memoryId },
+          });
+        } else {
+          saveItemsToStorage('memoryLikes', { memories: [{ memoryId, newLikeNum }] }, { memoryId, newLikeNum });
+        }
       });
 
   const likeButton = likeButtonGroup

--- a/src/client/helpers/helpers.js
+++ b/src/client/helpers/helpers.js
@@ -237,7 +237,7 @@ function constructTagList(data) {
 }
 
 // Will change this to storePendingActions in the next pull req - it is refactored to fit several actions
-function saveItemsToStorage(storedName, newObjToSave, itemToPush) {
+function storePendingActions(storedName, newObjToSave, itemToPush) {
   if (localStorage.getItem(storedName) !== null) {
     const itemsWaiting = JSON.parse(localStorage.getItem(storedName));
     itemsWaiting.memories.push(itemToPush);
@@ -262,8 +262,7 @@ function removeMemoryFromStoredData(id) {
 return offlineData;
 }
 
-// Refactored this in next PR - will change name to clearPendingActions
-function removeFromLocalStorage(storedName, index) {
+function clearPendingActions(storedName, index) {
   const memoriesWaitingToBeRemoved = JSON.parse(localStorage.getItem(storedName));
   if (memoriesWaitingToBeRemoved.memories.length === 1) {
     localStorage.removeItem(storedName);
@@ -284,7 +283,7 @@ function deletePendingMemories(cb) {
       method: 'DELETE',
       url: 'memories',
       data: { id: memory },
-      success: () => removeFromLocalStorage('toDelete', index),
+      success: () => clearPendingActions('toDelete', index),
     });
     cb();
   })
@@ -301,7 +300,7 @@ function updateOfflineLikes(cb) {
       type: 'POST',
       url: '/likes',
       data: { numLikes: newLikeNum, memoryId: id },
-      success: () => removeFromLocalStorage('memoryLikes', index),
+      success: () => clearPendingActions('memoryLikes', index),
     });
     cb();
   })
@@ -317,7 +316,7 @@ module.exports = {
     hideDeleteButton,
     showHeading,
     constructTagList,
-    saveItemsToStorage,
+    storePendingActions,
     updateOfflineLikes,
     hoveringOnDeleteSafari,
     deletePendingMemories,

--- a/src/client/helpers/helpers.js
+++ b/src/client/helpers/helpers.js
@@ -271,7 +271,7 @@ function removeFromLocalStorage(storedName, index) {
   else {
     memoriesWaitingToBeRemoved.memories.splice(index, 1);
     const memoriesStillToDelete = JSON.stringify(memoriesWaitingToBeRemoved);
-    localStorage.toDelete = memoriesStillToDelete;
+    localStorage.setItem('toDelete', memoriesStillToDelete);
 }
 }
 

--- a/src/client/helpers/helpers.js
+++ b/src/client/helpers/helpers.js
@@ -236,7 +236,6 @@ function constructTagList(data) {
   </li>`);
 }
 
-// Will change this to storePendingActions in the next pull req - it is refactored to fit several actions
 function storePendingActions(storedName, newObjToSave, itemToPush) {
   if (localStorage.getItem(storedName) !== null) {
     const itemsWaiting = JSON.parse(localStorage.getItem(storedName));

--- a/src/client/helpers/helpers.js
+++ b/src/client/helpers/helpers.js
@@ -220,16 +220,16 @@ function constructTagList(data) {
   </li>`);
 }
 
-function saveMemoryIdToStorage(id) {
-  if (localStorage.getItem('toDelete') !== null) {
-    const memoriesWaitingToBeRemoved = JSON.parse(localStorage.getItem("toDelete"));
-    memoriesWaitingToBeRemoved.memories.push(id);
-    const saveMemoriesToDelete = JSON.stringify(memoriesWaitingToBeRemoved);
-    localStorage.toDelete = saveMemoriesToDelete;
+function saveItemsToStorage(storedName, newObjToSave, itemToPush) {
+  if (localStorage.getItem(storedName) !== null) {
+    const itemsWaiting = JSON.parse(localStorage.getItem(storedName));
+    itemsWaiting.memories.push(itemToPush);
+    const itemsWaitingWithNewItem = JSON.stringify(itemsWaiting);
+    localStorage[storedName] = itemsWaitingWithNewItem;
   }
   else {
-    const saveDeletedMemory = JSON.stringify({memories: [id]});
-    localStorage.toDelete = saveDeletedMemory;
+    const saveObj = JSON.stringify(newObjToSave);
+    localStorage[storedName] = saveObj;
   }
 }
 
@@ -245,15 +245,15 @@ function removeMemoryFromStoredData(id) {
 return offlineData;
 }
 
-function removeMemoryFromLocalStorage(index) {
-  const memoriesWaitingToBeRemoved = JSON.parse(localStorage.getItem("toDelete"));
+function removeFromLocalStorage(storedName, index) {
+  const memoriesWaitingToBeRemoved = JSON.parse(localStorage.getItem(storedName));
   if (memoriesWaitingToBeRemoved.memories.length === 1) {
-    localStorage.removeItem('toDelete');
+    localStorage.removeItem(storedName);
   }
   else {
   memoriesWaitingToBeRemoved.memories.splice(index, 1);
   const memoriesStillToDelete = JSON.stringify(memoriesWaitingToBeRemoved);
-  localStorage.toDelete = memoriesStillToDelete;
+  localStorage[storedName] = memoriesStillToDelete;
 }
 }
 
@@ -266,7 +266,24 @@ function removeMemoriesDeletedOffline(cb) {
       method: 'DELETE',
       url: 'memories',
       data: { id: memory },
-      success: () => removeMemoryFromLocalStorage(index),
+      success: () => removeFromLocalStorage('toDelete', index),
+    });
+    cb();
+  })
+}
+}
+
+function updateOfflineLikes(cb) {
+  if(localStorage.getItem('memoryLikes') !== null) {
+  const newLikes = JSON.parse(localStorage.getItem('memoryLikes'));
+  newLikes.memories.forEach((memory, index) => {
+    const id = parseInt(memory.memoryId);
+    const newLikeNum = parseInt(memory.newLikeNum);
+    $.ajax({
+      type: 'POST',
+      url: '/likes',
+      data: { numLikes: newLikeNum, memoryId: id },
+      success: () => removeFromLocalStorage('memoryLikes', index),
     });
     cb();
   })
@@ -282,7 +299,8 @@ module.exports = {
     hideDeleteButton,
     showHeading,
     constructTagList,
-    saveMemoryIdToStorage,
+    saveItemsToStorage,
     removeMemoryFromStoredData,
     removeMemoriesDeletedOffline,
+    updateOfflineLikes,
 };


### PR DESCRIPTION
Extends on service worker pull request

- Refactors some functions for deleting logic so they also work for liking
- Adds logic and helpers for liking offline and sending updated likes to the DB when back online

relates to #138 #145 