### PR TITLE
Mobile bug fix

### DIFF
--- a/src/client/d3/d3.js
+++ b/src/client/d3/d3.js
@@ -203,8 +203,10 @@ function render(updatedData) {
     d.fx = d3.event.x;
     d.fy = d3.event.y;
     d3.select(this).style('fill', '#FDACAB');
-    const nodeTop = $(this).position().top;
+    const nodeTop = d3.event.y;
+    console.log('node top ', nodeTop);
     const buttonTop = $('.delete-button').position().top;
+    console.log('button top ', buttonTop);
     hoveringOnDelete(nodeTop, buttonTop);
   }
 

--- a/src/client/d3/d3.js
+++ b/src/client/d3/d3.js
@@ -203,7 +203,9 @@ function render(updatedData) {
     d.fx = d3.event.x;
     d.fy = d3.event.y;
     d3.select(this).style('fill', '#FDACAB');
-    hoveringOnDelete();
+    const nodeTop = $(this).position().top;
+    const buttonTop = $('.delete-button').position().top;
+    hoveringOnDelete(nodeTop, buttonTop);
   }
 
   function dragend(d) {

--- a/src/client/d3/d3.js
+++ b/src/client/d3/d3.js
@@ -1,4 +1,4 @@
-const { initTagMenu, showDeleteButton, hoveringOnDelete, hideDeleteButton, initSubmitMemory, tagSorting, constructTagList, showHeading } = require('../helpers/helpers.js');
+const { initTagMenu, showDeleteButton, hoveringOnDelete, hideDeleteButton, initSubmitMemory, tagSorting, constructTagList, showHeading, hoveringOnDeleteSafari } = require('../helpers/helpers.js');
 const { animationDuration, width, height, jsonUrl, svg, fdGrp, nodeGrp, linkGrp } = require('./setup.js');
 const { sortWithMax, binByTag, centralMaxNodesByTag, memoryNodesAndLinks } = require('../node_transformations');
 const { appendPopUp, randomPopUp } = require('./modals.js');
@@ -203,11 +203,15 @@ function render(updatedData) {
     d.fx = d3.event.x;
     d.fy = d3.event.y;
     d3.select(this).style('fill', '#FDACAB');
-    const nodeTop = d3.event.y;
-    console.log('node top ', nodeTop);
     const buttonTop = $('.delete-button').position().top;
-    console.log('button top ', buttonTop);
-    hoveringOnDelete(nodeTop, buttonTop);
+    const nodeTop = d3.event.y;
+    if (navigator.userAgent.indexOf('Safari') != -1 && navigator.userAgent.indexOf('Chrome') == -1) {
+      const height = $('#desktop-background').height();
+      const madness = (height - buttonTop);
+      hoveringOnDeleteSafari(nodeTop, madness);
+    } else {
+      hoveringOnDelete(nodeTop, buttonTop);
+    }
   }
 
   function dragend(d) {

--- a/src/client/helpers/helpers.js
+++ b/src/client/helpers/helpers.js
@@ -154,15 +154,17 @@ function showDeleteButton(d) {
   }, 1200);
 }
 
-function hoveringOnDelete() {
-    $('.delete-button').on('mouseover touchstart', () => {
+function hoveringOnDelete(nodeTop, buttonTop) {
+  if ($('.delete-button').is(':visible')) {
+  if (nodeTop >= buttonTop || buttonTop - 20 <= nodeTop) {
         $('.delete-button path').css('fill', '#FF3F56');
         $('.delete-button').addClass('deleting');
-    });
-    $('.delete-button').on('mouseleave touchend', () => {
+}
+  else {
         $('.delete-button path').css('fill', 'white');
         $('.delete-button').removeClass('deleting');
-    });
+  }
+}
 }
 
 function hideDeleteButton() {

--- a/src/client/helpers/helpers.js
+++ b/src/client/helpers/helpers.js
@@ -156,7 +156,7 @@ function showDeleteButton(d) {
 
 function hoveringOnDelete(nodeTop, buttonTop) {
   if ($('.delete-button').is(':visible')) {
-  if (nodeTop >= buttonTop || buttonTop - 20 <= nodeTop) {
+  if (nodeTop >= buttonTop || buttonTop - 40 <= nodeTop) {
         $('.delete-button path').css('fill', '#FF3F56');
         $('.delete-button').addClass('deleting');
 }

--- a/src/client/helpers/helpers.js
+++ b/src/client/helpers/helpers.js
@@ -155,11 +155,11 @@ function showDeleteButton(d) {
 }
 
 function hoveringOnDelete() {
-    $('.delete-button').on('mouseover', () => {
+    $('.delete-button').on('mouseover touchstart', () => {
         $('.delete-button path').css('fill', '#FF3F56');
         $('.delete-button').addClass('deleting');
     });
-    $('.delete-button').on('mouseleave', () => {
+    $('.delete-button').on('mouseleave touchend', () => {
         $('.delete-button path').css('fill', 'white');
         $('.delete-button').removeClass('deleting');
     });

--- a/src/client/helpers/helpers.js
+++ b/src/client/helpers/helpers.js
@@ -167,6 +167,19 @@ function hoveringOnDelete(nodeTop, buttonTop) {
 }
 }
 
+function hoveringOnDeleteSafari(nodeTop, buttonTop) {
+  if ($('.delete-button').is(':visible')) {
+  if (nodeTop + 40 >= buttonTop) {
+        $('.delete-button path').css('fill', '#FF3F56');
+        $('.delete-button').addClass('deleting');
+}
+  else {
+        $('.delete-button path').css('fill', 'white');
+        $('.delete-button').removeClass('deleting');
+  }
+}
+}
+
 function hideDeleteButton() {
     $('.delete-button').fadeOut();
     $('.menu > *:not(.delete-button)').fadeIn();
@@ -231,4 +244,5 @@ module.exports = {
     hideDeleteButton,
     showHeading,
     constructTagList,
+    hoveringOnDeleteSafari,
 };


### PR DESCRIPTION
We were unable to delete nodes on mobile because we were using 'mouseover'.

Attempted to use position of node and button from top to determine location which worked on most browsers but not on safari.

Did a separate calculation to get functionality on safari.

I hate safari.

relates #139 