### PR TITLE
Make sure menu-open checkbox is always hidden

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -61,7 +61,7 @@
 }
 
 .menu-open {
-    display: none;
+    display: none !important;
 }
 
 .menu-open:checked+.menu-open-button {


### PR DESCRIPTION
Add !important to display none on checkbox as it keeps appearing
relates #158