### PR TITLE
Hide close icon and restore menu icon on text memory submit

### DIFF
--- a/src/client/helpers/helpers.js
+++ b/src/client/helpers/helpers.js
@@ -196,7 +196,15 @@ function initSubmitMemory() {
                 .hide();
             $('.memory-input')
                 .addClass('hide');
+            $('.menu_icon')
+                .removeClass('hide');
+            $('.close_icon')
+                .addClass('hide');
             setTimeout(function() {
+                $('.menu-item')
+                    .show();
+                $('.menu-open')
+                    .prop('checked', false);
                 $('.finished svg')
                     .show();
                 $('.finished')

--- a/src/client/helpers/helpers.js
+++ b/src/client/helpers/helpers.js
@@ -200,6 +200,10 @@ function initSubmitMemory() {
                 .removeClass('hide');
             $('.close_icon')
                 .addClass('hide');
+            $(this)
+                .closest('form')
+                .find("input[type=text], textarea")
+                .val("");
             setTimeout(function() {
                 $('.menu-item')
                     .show();


### PR DESCRIPTION
Hide close icon on submit of text memory and restore menu back to normal once memory animation finishes
Also clears memory text inputs on submit

relates #189 #192 