### PR TITLE
Require in getRandomInt from node_transformations.js

### DIFF
--- a/src/client/d3/modals.js
+++ b/src/client/d3/modals.js
@@ -1,5 +1,6 @@
 const { svg } = require('./setup');
-const { getRandomInt, saveItemsToStorage } = require('./../helpers/helpers');
+const { saveItemsToStorage } = require('./../helpers/helpers');
+const { getRandomInt } = require('./../node_transformations');
 
 const appendPopUp = (data) => {
   const holder = svg


### PR DESCRIPTION
`getRandomInt` was being required in from the wrong file and so shuffle button wasn't working
relates #202